### PR TITLE
Updating the version for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.4.2]](https://github.com/lightspeeddevelopment/wetu-importer/releases/tag/1.4.2) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[1.4.1]](https://github.com/lightspeeddevelopment/wetu-importer/releases/tag/1.4.1) - 2023-04-20
 
 ### Added

--- a/lsx-importer-for-wetu.php
+++ b/lsx-importer-for-wetu.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/lightspeeddevelopment/lsx-wetu-importer
  * Description: By integrating with the Wetu Tour Operator system, you are able to import your content into the LSX Tour Operators plugin format
  * Author: LightSpeed
- * Version: 1.4.1
+ * Version: 1.4.2
  * Author URI: https://www.lsdev.biz/
  * License: GPL3+
  * Text Domain: lsx-wetu-importer
@@ -14,7 +14,7 @@
 define( 'LSX_WETU_IMPORTER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_WETU_IMPORTER_CORE', __FILE__ );
 define( 'LSX_WETU_IMPORTER_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_WETU_IMPORTER_VER', '1.4.1' );
+define( 'LSX_WETU_IMPORTER_VER', '1.4.2' );
 
 register_activation_hook( LSX_WETU_IMPORTER_CORE, array( 'LSX_WETU_Importer', 'register_activation_hook' ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-wetu-importer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tour Operators add-on for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, tour operator, tours, destination, accommodation
 Requires at least: 5.0
-Tested up to: 6.2
-Requires PHP: 7.2
-Stable tag: 1.4.1
+Tested up to: 6.3
+Requires PHP: 7.4
+Stable tag: 1.4.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag